### PR TITLE
Fixing headers not being shown

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class ObjectsToCsv {
     // as the first line of the file. Do not add it when we are appending
     // to an existing file.
     const fileNotExists = !fs.existsSync(filename) || fs.statSync(filename).size === 0;
-    if (fileNotExists) {
+    if (fileNotExists || !options || !options.append) {
       addHeader = true;
     }
 


### PR DESCRIPTION
Hi there, as I described on issue #3, headers are not being shown when the output file already exists even when the options.append is set to false (default value).
This PR only guarantees that headers will be included if append is not true.