### PR TITLE
switch from using maps and spread operators to for loops so that when…

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,9 +131,15 @@ async function convert(data, header = true, allColumns = false) {
   }
 
   // Add all other rows:
-  csvInput.push(
-    ...data.map(row => columnNames.map(column => row[column])),
-  );
+  const allData = []
+  for(let i = 0; i < data.length; i++) {
+    const row = data[i]
+    allData.push(columnNames.map(column => row[column]))
+  }
+
+  for(let i = 0; i < allData.length; i++) {
+    csvInput.push(allData[i])
+  }
 
   return await csv.stringify(csvInput);
 }


### PR DESCRIPTION
… large datasets are used the maximum call stack is not exceeded

When converting a large object (like ~150k records) to the csv arrays, the maximum call stack gets exceeded by invoking the map callback on the data variable. Instead if we just use a regular for-loop to push the in to the csvInput array, we don't need to invoke a callback for each record. Hope this helps and please let me know if you have any questions :)

Thanks for making this! It's super helpful