### PR TITLE
Correction BOM mark never really appended.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class ObjectsToCsv {
     // Append the BOM mark if requested at the beginning of the file, otherwise
     // Excel won't show Unicode correctly. The actual BOM mark will be EF BB BF,
     // see https://stackoverflow.com/a/27975629/6269864 for details.
-    if (options && options.bom && fileNotExists) {
+    if (options && options.bom) {
       data = '\ufeff' + data;
     }
 


### PR DESCRIPTION
Excel was not showing Unicode correctly.
The if statement that checks for the BOM option had a logic error, it was erroneously checking for the BOM and fileNotExists.
When deleting fileNotExists == true condition from the if statement the Excel started to display Unicode correctly.